### PR TITLE
Fix an issue with collections in the autocomplete endpoint

### DIFF
--- a/src/components/autocomplete/Autocomplete.ts
+++ b/src/components/autocomplete/Autocomplete.ts
@@ -16,8 +16,10 @@ export default class Autocomplete extends AbstractComponent {
     limit?: IAutocompleteParams["limit"]
   ): Promise<IAutocompleteResult> {
     const params: IAutocompleteParams = { query };
-    if (collection_ids) {
-      params.collection_ids = collection_ids;
+    if (Array.isArray(collection_ids)) {
+      // 'collection_ids' in the autocomplete endpoint expects a comma separated list
+      // as a workaround, we stringify the array before calling the endpoint
+      params.collection_ids = collection_ids.join(',') as any;
     }
     if (limit) {
       params.limit = limit;


### PR DESCRIPTION
The endpoint expects a comma-separated list of strings as a parameter of the GET call,
but passing the string list to the http client fails to perform the proper stringification.

This results in the autocomplete endpoint ignoring the 'collection_ids' parameter, and
returning results across all collections.

This fix is not elegant, but is a workaround that performs the string conversion before
calling the client.