### PR TITLE
Add supported collection_ids to the autocomplete endpoint

### DIFF
--- a/src/components/autocomplete/Autocomplete.types.ts
+++ b/src/components/autocomplete/Autocomplete.types.ts
@@ -4,7 +4,11 @@ export interface IAutocompleteParams {
   query: string;
   collection_ids?: (
     | "organizations"
+    | "organization.companies"
+    | "organization.investors"
+    | "organization.schools"
     | "people"
+    | "person.investors"
     | "funding_rounds"
     | "acquisitions"
     | "investments"
@@ -18,6 +22,7 @@ export interface IAutocompleteParams {
     | "category_groups"
     | "locations"
     | "jobs"
+    | "principals"
   )[];
   limit?: number;
 }


### PR DESCRIPTION
This allows to look more narrowly in autocompletion options, such as only within
organization > companies (which excludes investors and schools).

This is documented on https://data.crunchbase.com/docs/using-autocomplete-api and
values derive from facet_ids on the documentation of Organization and Person
entities.